### PR TITLE
Add power consumption tracking (meter_power / measure_power)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8c307ef1-119b-4855-8e2c-3da684493cad","pid":60608,"acquiredAt":1778592967521}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "PowerShell(Get-ChildItem 'C:\\\\code\\\\homey\\\\viessmann-documentation-backup' -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName })"
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Viessmann ViCare API credentials for scripts/testConnection.js
+#
+# Get a CLIENT_ID by registering an app at https://developer.viessmann.com
+# A REFRESH_TOKEN can be obtained via scripts/getRefreshToken.js.
+#
+# Do NOT commit the real .env file - it is git-ignored.
+
+VIESSMANN_CLIENT_ID=
+VIESSMANN_REFRESH_TOKEN=
+
+# Optional - only used by the SIMULATION block of scripts/testConnection.js
+# to also fetch the live meter_power / measure_power values from your Homey
+# and compare against what the driver would compute. Leave blank to skip.
+#
+# HOMEY_LOCAL_URL  - the homeylocal.com URL printed by `homey app install`
+#                    (e.g. https://192-168-20-54.homey.homeylocal.com)
+# HOMEY_TOKEN      - bearer token from %APPDATA%\athom-cli\settings.json
+#                    under homeyApi.homey-<id>.token
+# HOMEY_DEVICE_ID  - Homey UUID of the Viessmann device; find it via
+#                    GET /api/manager/devices/device on the Homey local API
+HOMEY_LOCAL_URL=
+HOMEY_TOKEN=
+HOMEY_DEVICE_ID=
+
+# Optional - if set, lifetimeKwh is seeded with this value on the very
+# first simulation run (before any state file exists). Use this to start
+# the simulation from the value currently shown in Homey for the
+# meter_power capability.
+VIESSMANN_LIFETIME_SEED=

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 **/.DS_Store
 .DS_Store
 app.json
+.env
+.env.local
+scripts/.testConnection.state.json
+scripts/.testConnection.poll.log

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "se.forint.pelle.viessmann",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "compatibility": ">=10.0.0",
   "sdk": 3,
   "platforms": [
@@ -41,6 +41,11 @@
     "getFeatures": {
       "method": "POST",
       "path": "/features",
+      "oauth2": true
+    },
+    "refreshPower": {
+      "method": "POST",
+      "path": "/refreshPower",
       "oauth2": true
     },
     "getDevices": {

--- a/api.js
+++ b/api.js
@@ -50,6 +50,29 @@ module.exports = {
     }
   },
 
+  async refreshPower({ homey, body }) {
+    try {
+      const { deviceId } = body;
+      if (!deviceId) throw new Error('Device ID is required');
+
+      const driver = homey.drivers.getDriver('vicare');
+      const devices = driver.getDevices();
+      const device = devices.find((d) => d.getData().id === deviceId);
+      if (!device) throw new Error(`No device found with ID: ${deviceId}`);
+
+      const features = await device.getFeatures(false);
+      await device.onFeaturesUpdated(features, false);
+
+      return {
+        meter_power: device.getCapabilityValue('meter_power'),
+        measure_power: device.getCapabilityValue('measure_power'),
+      };
+    } catch (error) {
+      homey.error('Error in refreshPower API:', error);
+      throw error;
+    }
+  },
+
   async getDevices({ homey }) {
     try {
       const driver = homey.drivers.getDriver('vicare');

--- a/app.json
+++ b/app.json
@@ -348,9 +348,20 @@
       "class": "heater",
       "capabilities": [
         "meter_power",
-        "measure_power"
+        "measure_power",
+        "button.refresh"
       ],
-      "capabilitiesOptions": {},
+      "capabilitiesOptions": {
+        "button.refresh": {
+          "title": {
+            "en": "Refresh"
+          },
+          "desc": {
+            "en": "Fetch the latest data from the Viessmann API now"
+          },
+          "maintenanceAction": true
+        }
+      },
       "energy": {},
       "platforms": [
         "local"

--- a/app.json
+++ b/app.json
@@ -346,22 +346,8 @@
         "en": "ViCare"
       },
       "class": "heater",
-      "capabilities": [
-        "meter_power",
-        "measure_power",
-        "button.refresh"
-      ],
-      "capabilitiesOptions": {
-        "button.refresh": {
-          "title": {
-            "en": "Refresh"
-          },
-          "desc": {
-            "en": "Fetch the latest data from the Viessmann API now"
-          },
-          "maintenanceAction": true
-        }
-      },
+      "capabilities": [],
+      "capabilitiesOptions": {},
       "energy": {},
       "platforms": [
         "local"
@@ -411,6 +397,34 @@
           "min": 1,
           "step": 1,
           "units": "min"
+        },
+        {
+          "id": "baselineW",
+          "type": "number",
+          "label": {
+            "en": "Baseline power draw (W)"
+          },
+          "hint": {
+            "en": "Estimated standby power draw when the compressor is OFF (circulator pump, controller, etc.). Used to compute live measure_power when no kWh delta is available."
+          },
+          "value": 150,
+          "min": 0,
+          "step": 10,
+          "units": "W"
+        },
+        {
+          "id": "maxCompressorW",
+          "type": "number",
+          "label": {
+            "en": "Max compressor power draw (W)"
+          },
+          "hint": {
+            "en": "Estimated electrical draw of the compressor at its maximum speed (typically ~120 rps for inverter heat pumps). Live measure_power is scaled linearly from compressor.speed when the compressor is active. Tune to match what the Viessmann ViCare app shows during a steady-state cycle. Set to 0 to disable the compressor-based estimate and fall back to kWh-delta derivation."
+          },
+          "value": 3500,
+          "min": 0,
+          "step": 100,
+          "units": "W"
         }
       ]
     }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "se.forint.pelle.viessmann",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "compatibility": ">=10.0.0",
   "sdk": 3,
   "platforms": [
@@ -42,6 +42,11 @@
     "getFeatures": {
       "method": "POST",
       "path": "/features",
+      "oauth2": true
+    },
+    "refreshPower": {
+      "method": "POST",
+      "path": "/refreshPower",
       "oauth2": true
     },
     "getDevices": {
@@ -341,8 +346,12 @@
         "en": "ViCare"
       },
       "class": "heater",
-      "capabilities": [],
+      "capabilities": [
+        "meter_power",
+        "measure_power"
+      ],
       "capabilitiesOptions": {},
+      "energy": {},
       "platforms": [
         "local"
       ],
@@ -375,6 +384,22 @@
         {
           "id": "login_oauth2",
           "template": "login_oauth2"
+        }
+      ],
+      "settings": [
+        {
+          "id": "pollInterval",
+          "type": "number",
+          "label": {
+            "en": "Poll interval (minutes)"
+          },
+          "hint": {
+            "en": "How often this device polls the Viessmann API. The free Basic tier allows 120 calls per day per Client ID — keep this high enough that calls/day × devices stays under that limit."
+          },
+          "value": 2,
+          "min": 1,
+          "step": 1,
+          "units": "min"
         }
       ]
     }

--- a/drivers/vicare/__tests__/device.test.js
+++ b/drivers/vicare/__tests__/device.test.js
@@ -240,6 +240,8 @@ describe('ViessmannDevice capability handling', () => {
         if (status && status !== 'connected') continue;
 
         for (const capability of featureConfig.capabilities) {
+          // Derived capabilities (e.g. measure_power) are computed in device.js, not via propertyPath
+          if (capability.derived) continue;
           testCases.push([
             featurePath,
             capability.capabilityName,

--- a/drivers/vicare/config.js
+++ b/drivers/vicare/config.js
@@ -50,7 +50,14 @@ const PATHS = {
   FUEL_CELL_STATS: 'fuelCell.statistics',
   FUEL_CELL_PHASE: 'fuelCell.operating.phase',
   FUEL_CELL_MODE: 'fuelCell.operating.modes.active',
-  POWER_CONSUMPTION_TOTAL: 'heating.power.consumption.total',
+  POWER_CONSUMPTION_SUMMARY_HEATING: 'heating.power.consumption.summary.heating',
+  POWER_CONSUMPTION_SUMMARY_DHW: 'heating.power.consumption.summary.dhw',
+  POWER_CONSUMPTION_SUMMARY_COOLING: 'heating.power.consumption.summary.cooling',
+  // Live activity signals used by device.js to derive an instantaneous
+  // measure_power estimate (the API does not expose a direct W sensor on
+  // most Vitocal models, so we infer from compressor activity).
+  COMPRESSOR_SPEED: 'heating.compressors.0.speed.current',
+  PRIMARY_FAN_MODULATION: 'heating.primaryCircuit.fans.0.current',
 };
 
 // Gemensamma capability-mallar
@@ -393,7 +400,11 @@ module.exports = {
         },
       }],
     },
-    [PATHS.POWER_CONSUMPTION_TOTAL]: {
+    // meter_power / measure_power are derived from the sum of currentDay across
+    // summary.heating + summary.dhw + summary.cooling (see device.js). They are
+    // declared here on summary.heating so the capability addition loop in
+    // device.js:120 picks them up whenever that feature is enabled.
+    [PATHS.POWER_CONSUMPTION_SUMMARY_HEATING]: {
       capabilities: [
         {
           capabilityName: 'meter_power',
@@ -417,6 +428,16 @@ module.exports = {
         },
       ],
     },
+    // DHW and cooling summary features carry no Homey capability of their own —
+    // they are only used as additional inputs to the aggregated currentDay sum.
+    // An entry must exist here, otherwise the loop in device.js skips them as
+    // "unknown feature".
+    [PATHS.POWER_CONSUMPTION_SUMMARY_DHW]: { capabilities: [] },
+    [PATHS.POWER_CONSUMPTION_SUMMARY_COOLING]: { capabilities: [] },
+    // Compressor speed and primary fan modulation feed the live-wattage
+    // estimate computed in device.js. No Homey capability of their own.
+    [PATHS.COMPRESSOR_SPEED]: { capabilities: [] },
+    [PATHS.PRIMARY_FAN_MODULATION]: { capabilities: [] },
     [PATHS.FUEL_CELL_MODE]: {
       capabilities: [{
         capabilityName: 'thermostat_mode.fuelCell',

--- a/drivers/vicare/config.js
+++ b/drivers/vicare/config.js
@@ -50,6 +50,7 @@ const PATHS = {
   FUEL_CELL_STATS: 'fuelCell.statistics',
   FUEL_CELL_PHASE: 'fuelCell.operating.phase',
   FUEL_CELL_MODE: 'fuelCell.operating.modes.active',
+  POWER_CONSUMPTION_TOTAL: 'heating.power.consumption.total',
 };
 
 // Gemensamma capability-mallar
@@ -391,6 +392,30 @@ module.exports = {
           },
         },
       }],
+    },
+    [PATHS.POWER_CONSUMPTION_TOTAL]: {
+      capabilities: [
+        {
+          capabilityName: 'meter_power',
+          propertyPath: '_derived',
+          derived: true,
+          capabilityOptions: {
+            title: { en: 'Energy' },
+            units: 'kWh',
+            decimals: 3,
+          },
+        },
+        {
+          capabilityName: 'measure_power',
+          propertyPath: '_derived',
+          derived: true,
+          capabilityOptions: {
+            title: { en: 'Power' },
+            units: 'W',
+            decimals: 0,
+          },
+        },
+      ],
     },
     [PATHS.FUEL_CELL_MODE]: {
       capabilities: [{

--- a/drivers/vicare/device.js
+++ b/drivers/vicare/device.js
@@ -30,6 +30,13 @@ module.exports = class ViessmannDevice extends OAuth2Device {
   static FEATURES = FEATURES;
   static PATHS = PATHS;
   static STATIC_CAPABILITIES = ['button.refresh'];
+  // If the Viessmann API timestamp on the summary.* features stops
+  // advancing for longer than this, assume the heat pump is idle and
+  // force measure_power to 0. Otherwise the capability stays stuck at
+  // whatever watts value was computed from the last positive delta —
+  // observed: 7181 W left over from an earlier active cycle while the
+  // device was actually drawing 0 W.
+  static MAX_STALE_POWER_MS = 15 * 60 * 1000;
 
   async onOAuth2Init() {
     await this.checkUpgradeSpecifics();
@@ -312,6 +319,38 @@ module.exports = class ViessmannDevice extends OAuth2Device {
       this.setStoreValue('constraints', constraints);
       this.setStoreValue('version', '1.0.15');
     }
+    // 1.0.16: meter_power / measure_power source switched from
+    // heating.power.consumption.total (whose inner `day` array can be 40+
+    // hours stale) to the sum of heating.power.consumption.summary.*
+    // currentDay values. Refresh _features so the new paths are recognised,
+    // and reset the accumulator's per-day cache so the next poll seeds
+    // cleanly from the new source instead of computing a spurious delta
+    // against the old `day.value[0]` value.
+    if (this.storeVersionBefore('1.0.16')) {
+      this.log('Upgrading to 1.0.16: switching power source to summary.*');
+      const installationId = this.getStoreValue('installationId');
+      const gatewaySerial = this.getStoreValue('gatewaySerial');
+      const deviceId = this.getStoreValue('deviceId');
+      const { features, constraints } = await this.driver._getEnabledFeaturesAndOpModes(this.oAuth2Client, installationId, gatewaySerial, deviceId);
+      this.setStoreValue('features', features);
+      this.setStoreValue('constraints', constraints);
+      await this.unsetStoreValue('lastDayKwh');
+      await this.unsetStoreValue('lastApiTimestamp');
+      this.setStoreValue('version', '1.0.16');
+    }
+    // 1.0.17: live measure_power derivation from compressor + fan. Refresh
+    // _features so the new compressor.speed.current and primary fan paths
+    // are recognised by the polling loop.
+    if (this.storeVersionBefore('1.0.17')) {
+      this.log('Upgrading to 1.0.17: refreshing features for live-wattage paths');
+      const installationId = this.getStoreValue('installationId');
+      const gatewaySerial = this.getStoreValue('gatewaySerial');
+      const deviceId = this.getStoreValue('deviceId');
+      const { features, constraints } = await this.driver._getEnabledFeaturesAndOpModes(this.oAuth2Client, installationId, gatewaySerial, deviceId);
+      this.setStoreValue('features', features);
+      this.setStoreValue('constraints', constraints);
+      this.setStoreValue('version', '1.0.17');
+    }
   }
 
   async onFeaturesUpdated(response, extendedResponse) {
@@ -341,6 +380,39 @@ module.exports = class ViessmannDevice extends OAuth2Device {
         }
       }
 
+      // Helper to safely get nested property values; hoisted out of the loop so
+      // the post-loop power aggregation can reuse it.
+      const getValue = (obj, path) => {
+        try {
+          return path.split('.').reduce((acc, part) => acc && acc[part], obj);
+        } catch (error) {
+          if (process.env.DEBUG) {
+            this.log(`Error getting value for path: ${path}, error:`, error);
+          }
+          return undefined;
+        }
+      };
+
+      // Collect today's kWh from the three summary.* features as they pass
+      // through the loop, then aggregate into meter_power / measure_power once
+      // the loop has finished. See the long comment below the loop for why.
+      const POWER_SUMMARY_PATHS = [
+        PATHS.POWER_CONSUMPTION_SUMMARY_HEATING,
+        PATHS.POWER_CONSUMPTION_SUMMARY_DHW,
+        PATHS.POWER_CONSUMPTION_SUMMARY_COOLING,
+      ];
+      const summaryCurrentDay = {};
+      let latestSummaryTimestampMs = null;
+
+      // Live activity signals — used to derive an instantaneous measure_power
+      // estimate, since the API has no direct wattage sensor on most Vitocal
+      // models (heating.inverters.0.sensors.power.current returns
+      // status=notConnected). compressor.active updates within ~30s vs. the
+      // kWh-summary counters which tick only every 5–20 min.
+      let compressorActive = null;
+      let compressorSpeedRps = null;
+      let fanModulationPct = null;
+
       for (const feature of response.data) {
         if (!feature.isEnabled || !feature.properties || feature.properties?.status?.value === 'notConnected') {
           if (process.env.DEBUG && !extendedResponse) {
@@ -365,23 +437,6 @@ module.exports = class ViessmannDevice extends OAuth2Device {
           continue;
         }
 
-        if (process.env.DEBUG && !extendedResponse) {
-          // this.log(`Processing feature: ${feature.feature}`);
-        }
-
-        // Helper function to safely get nested property values
-        const getValue = (obj, path) => {
-          // if error, return undefined
-          try {
-            return path.split('.').reduce((acc, part) => acc && acc[part], obj);
-          } catch (error) {
-            if (process.env.DEBUG) {
-              this.log(`Error getting value for path: ${path}, error:`, error);
-            }
-            return undefined;
-          }
-        };
-
         // Update all capabilities associated with this feature
         for (const capability of featureConfig.capabilities) {
           // Derived capabilities are computed elsewhere (e.g. measure_power from kWh delta)
@@ -389,73 +444,139 @@ module.exports = class ViessmannDevice extends OAuth2Device {
 
           const value = getValue(feature.properties, capability.propertyPath);
           if (value !== undefined) {
-            if (process.env.DEBUG) {
-              // this.log(`Setting capability: ${capability.capabilityName} = ${value} (from ${capability.propertyPath})`);
-            }
             await this.setCapabilityValueIfPossible(capability.capabilityName, value);
           } else if (process.env.DEBUG) {
             this.log(`No value found for capability: ${capability.capabilityName}, path: ${capability.propertyPath}`);
           }
         }
 
-        // Viessmann's day[0] is today's kWh and resets at midnight. Homey's Energy tab requires
-        // a monotonically increasing meter_power (energy.cumulative: true), so accumulate positive
-        // deltas into a lifetime total persisted in device store. measure_power (W) is derived
-        // from the API's own update timestamp (feature.timestamp) — using wall-clock poll time
-        // produces fake spikes when a 0.1 kWh chunk that accumulated over hours is attributed to
-        // the gap between two polls.
-        if (feature.feature === PATHS.POWER_CONSUMPTION_TOTAL) {
-          const todayKwh = getValue(feature.properties, 'day.value.0');
-          const apiTimestampMs = feature.timestamp ? Date.parse(feature.timestamp) : NaN;
-          this.log(`[power] raw day.value.0 = ${todayKwh} apiTimestamp = ${feature.timestamp}`);
-          if (typeof todayKwh === 'number' && Number.isFinite(apiTimestampMs)) {
-            const lastDayKwh = this.getStoreValue('lastDayKwh');
-            const lastApiTimestamp = this.getStoreValue('lastApiTimestamp');
-            const previousLifetime = this.getStoreValue('lifetimeKwh');
-            const lifetimeBase = typeof previousLifetime === 'number' ? previousLifetime : 0;
-
-            let deltaKwh;
-            let deltaReason;
-            if (typeof lastDayKwh !== 'number') {
-              deltaKwh = todayKwh;
-              deltaReason = 'first reading (seeded)';
-            } else if (todayKwh >= lastDayKwh) {
-              deltaKwh = todayKwh - lastDayKwh;
-              deltaReason = 'today >= last';
-            } else {
-              deltaKwh = todayKwh;
-              deltaReason = 'midnight reset';
+        if (POWER_SUMMARY_PATHS.includes(feature.feature)) {
+          const currentDay = getValue(feature.properties, 'currentDay.value');
+          if (typeof currentDay === 'number') {
+            summaryCurrentDay[feature.feature] = currentDay;
+            const tsMs = feature.timestamp ? Date.parse(feature.timestamp) : NaN;
+            if (Number.isFinite(tsMs) && (latestSummaryTimestampMs === null || tsMs > latestSummaryTimestampMs)) {
+              latestSummaryTimestampMs = tsMs;
             }
+          }
+        }
+        if (feature.feature === PATHS.COMPRESSOR) {
+          const v = getValue(feature.properties, 'active.value');
+          if (typeof v === 'boolean') compressorActive = v;
+        }
+        if (feature.feature === PATHS.COMPRESSOR_SPEED) {
+          const v = getValue(feature.properties, 'value.value');
+          if (typeof v === 'number') compressorSpeedRps = v;
+        }
+        if (feature.feature === PATHS.PRIMARY_FAN_MODULATION) {
+          const v = getValue(feature.properties, 'value.value');
+          if (typeof v === 'number') fanModulationPct = v;
+        }
+      }
 
-            const lifetimeKwh = lifetimeBase + deltaKwh;
-            const apiAdvanced = typeof lastApiTimestamp === 'number' && apiTimestampMs > lastApiTimestamp;
-            const deltaHours = typeof lastApiTimestamp === 'number'
-              ? (apiTimestampMs - lastApiTimestamp) / 3600000
-              : null;
-            this.log(
-              `[power] todayKwh=${todayKwh} lastDayKwh=${lastDayKwh} deltaKwh=${deltaKwh} (${deltaReason}) `
-              + `lifetimeBase=${lifetimeBase} lifetimeKwh=${lifetimeKwh} `
-              + `lastApiTimestamp=${lastApiTimestamp} apiAdvanced=${apiAdvanced} deltaHours=${deltaHours}`,
-            );
+      // Aggregate today's kWh from the three summary.* features and feed the
+      // monotonic lifetime accumulator (Homey's Energy tab requires meter_power
+      // to be cumulative). measure_power is derived from the delta over the
+      // API's own timestamp, not wall-clock poll time, to avoid fake spikes
+      // when a chunk that accumulated over hours is attributed to the gap
+      // between two polls.
+      //
+      // Why summary.* instead of heating.power.consumption.total: the
+      // outer feature.timestamp on `.total` updates each poll, but the inner
+      // `dayValueReadAt` can be 40+ hours stale on some devices (observed on
+      // Vitocal 222S), so the old `day.value[0]`-based path silently froze.
+      // The summary.{heating,dhw,cooling} features expose a fresh
+      // `currentDay` property whose values sum to the figure shown in the
+      // Viessmann mobile app.
+      // First: kWh accumulator (meter_power, always — this is the lifetime
+      // counter Homey's Energy tab requires). Capture deltaKwh/apiAdvanced so
+      // the measure_power fallback below can reuse them without re-reading
+      // state that has just been updated.
+      let kwhDeltaKwh = null;
+      let kwhApiAdvanced = false;
+      let kwhDeltaHours = null;
+      const summaryKeys = Object.keys(summaryCurrentDay);
+      if (summaryKeys.length > 0 && latestSummaryTimestampMs !== null) {
+        const todayKwh = Object.values(summaryCurrentDay).reduce((sum, v) => sum + v, 0);
+        const apiTimestampMs = latestSummaryTimestampMs;
+        const breakdown = summaryKeys.map((k) => `${k.split('.').pop()}=${summaryCurrentDay[k]}`).join(' ');
 
-            await this.setStoreValue('lifetimeKwh', lifetimeKwh);
-            await this.setStoreValue('lastDayKwh', todayKwh);
-            await this.setCapabilityValueIfPossible('meter_power', lifetimeKwh);
+        const lastDayKwh = this.getStoreValue('lastDayKwh');
+        const lastApiTimestamp = this.getStoreValue('lastApiTimestamp');
+        const previousLifetime = this.getStoreValue('lifetimeKwh');
+        const lifetimeBase = typeof previousLifetime === 'number' ? previousLifetime : 0;
 
-            if (apiAdvanced && deltaHours > 0) {
-              const watts = Math.max(0, (deltaKwh / deltaHours) * 1000);
-              this.log(`[power] measure_power = ${watts} W (deltaKwh=${deltaKwh} / deltaHours=${deltaHours} * 1000)`);
-              await this.setStoreValue('lastMeasurePower', watts);
-              await this.setCapabilityValueIfPossible('measure_power', watts);
-              await this.setStoreValue('lastApiTimestamp', apiTimestampMs);
-            } else if (typeof lastApiTimestamp !== 'number') {
-              this.log('[power] first reading — recording API timestamp, deferring measure_power until next update');
-              await this.setStoreValue('lastApiTimestamp', apiTimestampMs);
-            } else {
-              this.log(`[power] API counter not advanced yet (last=${lastApiTimestamp}, now=${apiTimestampMs}) — leaving measure_power unchanged`);
+        let deltaReason;
+        if (typeof lastDayKwh !== 'number') {
+          kwhDeltaKwh = todayKwh;
+          deltaReason = 'first reading (seeded)';
+        } else if (todayKwh >= lastDayKwh) {
+          kwhDeltaKwh = todayKwh - lastDayKwh;
+          deltaReason = 'today >= last';
+        } else {
+          kwhDeltaKwh = todayKwh;
+          deltaReason = 'midnight reset';
+        }
+
+        const lifetimeKwh = lifetimeBase + kwhDeltaKwh;
+        kwhApiAdvanced = typeof lastApiTimestamp === 'number' && apiTimestampMs > lastApiTimestamp;
+        kwhDeltaHours = typeof lastApiTimestamp === 'number'
+          ? (apiTimestampMs - lastApiTimestamp) / 3600000 : null;
+        this.log(
+          `[power] todayKwh=${todayKwh} (${breakdown}) lastDayKwh=${lastDayKwh} deltaKwh=${kwhDeltaKwh} (${deltaReason}) `
+          + `lifetimeKwh=${lifetimeKwh} apiAdvanced=${kwhApiAdvanced} deltaHours=${kwhDeltaHours}`,
+        );
+
+        await this.setStoreValue('lifetimeKwh', lifetimeKwh);
+        await this.setStoreValue('lastDayKwh', todayKwh);
+        await this.setCapabilityValueIfPossible('meter_power', lifetimeKwh);
+
+        if (kwhApiAdvanced || typeof lastApiTimestamp !== 'number') {
+          await this.setStoreValue('lastApiTimestamp', apiTimestampMs);
+        }
+      }
+
+      // measure_power derivation. Prefer the live compressor-based estimate
+      // when the user has maxCompressorW > 0 — it tracks the heat pump within
+      // ~30 s of the compressor turning on/off, instead of lagging the kWh
+      // summary chunks by 5–20 min. Falls back to the kWh-delta path when the
+      // compressor signals are missing or the user has disabled the live
+      // estimate (maxCompressorW = 0).
+      // Setting defaults apply only to newly-paired devices. For existing
+      // devices the setting comes back undefined, so apply the same defaults
+      // in code as in driver.compose.json.
+      const rawMaxW = Number(this.getSetting('maxCompressorW'));
+      const rawBaseW = Number(this.getSetting('baselineW'));
+      const maxCompressorW = Number.isFinite(rawMaxW) ? rawMaxW : 3500;
+      const baselineW = Number.isFinite(rawBaseW) ? rawBaseW : 150;
+      const MAX_COMPRESSOR_RPS = 120;
+
+      if (maxCompressorW > 0 && typeof compressorActive === 'boolean') {
+        let watts;
+        if (compressorActive) {
+          const speedRatio = Math.min(1, Math.max(0, (compressorSpeedRps || 0) / MAX_COMPRESSOR_RPS));
+          watts = baselineW + speedRatio * maxCompressorW;
+        } else {
+          watts = baselineW;
+        }
+        this.log(`[power] measure_power (live) = ${Math.round(watts)} W  compressor=${compressorActive} speed=${compressorSpeedRps}rps fan=${fanModulationPct}%`);
+        await this.setStoreValue('lastMeasurePower', watts);
+        await this.setCapabilityValueIfPossible('measure_power', watts);
+      } else if (kwhDeltaKwh !== null) {
+        if (kwhApiAdvanced && kwhDeltaHours > 0) {
+          const watts = Math.max(0, (kwhDeltaKwh / kwhDeltaHours) * 1000);
+          this.log(`[power] measure_power (kWh-delta) = ${Math.round(watts)} W`);
+          await this.setStoreValue('lastMeasurePower', watts);
+          await this.setCapabilityValueIfPossible('measure_power', watts);
+        } else {
+          const lastApiTimestamp = this.getStoreValue('lastApiTimestamp');
+          if (typeof lastApiTimestamp === 'number') {
+            const staleMs = Date.now() - lastApiTimestamp;
+            if (staleMs > this.constructor.MAX_STALE_POWER_MS) {
+              this.log(`[power] API timestamp stale for ${Math.round(staleMs / 60000)} min — assuming idle, setting measure_power=0`);
+              await this.setStoreValue('lastMeasurePower', 0);
+              await this.setCapabilityValueIfPossible('measure_power', 0);
             }
-          } else {
-            this.log(`[power] todayKwh not a number, skipping (type=${typeof todayKwh})`);
           }
         }
       }
@@ -560,10 +681,16 @@ module.exports = class ViessmannDevice extends OAuth2Device {
     this.driver._stopPolling(deviceKey);
   }
 
-  async onSettings({ changedKeys }) {
+  async onSettings({ newSettings, changedKeys }) {
     if (changedKeys.includes('pollInterval')) {
       const deviceKey = `${this._installationId}-${this._gatewaySerial}-${this._deviceId}`;
-      await this.driver._startPolling(this, deviceKey);
+      // Pass the new value through explicitly. device.getSetting() inside
+      // onSettings can still return the OLD value before the change is
+      // committed, which is why the previous version of this handler
+      // appeared to "ignore" pollInterval changes until app restart.
+      const intervalMs = this.driver.constructor._toIntervalMs(newSettings.pollInterval);
+      this.log(`pollInterval changed to ${newSettings.pollInterval} min → restarting polling at ${intervalMs / 1000}s`);
+      await this.driver._startPolling(this, deviceKey, intervalMs);
     }
   }
 

--- a/drivers/vicare/device.js
+++ b/drivers/vicare/device.js
@@ -54,10 +54,16 @@ module.exports = class ViessmannDevice extends OAuth2Device {
     }
 
     this._listeners = [];
+    this._lastPowerTimestamp = this.getStoreValue('lastPowerTimestamp') || null;
 
     await this.initializeCapabilities();
     await this.initializeOperatingModes();
     await this.registerCapabilityListeners();
+
+    const lastMeasurePower = this.getStoreValue('lastMeasurePower');
+    if (typeof lastMeasurePower === 'number') {
+      await this.setCapabilityValueIfPossible('measure_power', lastMeasurePower);
+    }
 
     this.onFeaturesUpdated = this.onFeaturesUpdated.bind(this);
 
@@ -281,6 +287,17 @@ module.exports = class ViessmannDevice extends OAuth2Device {
       await this.updateCapabilityOptions();
       this.setStoreValue('version', '1.0.9');
     }
+    // 1.0.15: refresh features from API to pick up new config entries (e.g. heating.power.consumption.total)
+    if (this.storeVersionBefore('1.0.15')) {
+      this.log('Upgrading to 1.0.15: refreshing features from API');
+      const installationId = this.getStoreValue('installationId');
+      const gatewaySerial = this.getStoreValue('gatewaySerial');
+      const deviceId = this.getStoreValue('deviceId');
+      const { features, constraints } = await this.driver._getEnabledFeaturesAndOpModes(this.oAuth2Client, installationId, gatewaySerial, deviceId);
+      this.setStoreValue('features', features);
+      this.setStoreValue('constraints', constraints);
+      this.setStoreValue('version', '1.0.15');
+    }
   }
 
   async onFeaturesUpdated(response, extendedResponse) {
@@ -353,6 +370,9 @@ module.exports = class ViessmannDevice extends OAuth2Device {
 
         // Update all capabilities associated with this feature
         for (const capability of featureConfig.capabilities) {
+          // Derived capabilities are computed elsewhere (e.g. measure_power from kWh delta)
+          if (capability.derived) continue;
+
           const value = getValue(feature.properties, capability.propertyPath);
           if (value !== undefined) {
             if (process.env.DEBUG) {
@@ -361,6 +381,49 @@ module.exports = class ViessmannDevice extends OAuth2Device {
             await this.setCapabilityValueIfPossible(capability.capabilityName, value);
           } else if (process.env.DEBUG) {
             this.log(`No value found for capability: ${capability.capabilityName}, path: ${capability.propertyPath}`);
+          }
+        }
+
+        // Viessmann's day[0] is today's kWh and resets at midnight. Homey's Energy tab requires
+        // a monotonically increasing meter_power (energy.cumulative: true), so accumulate positive
+        // deltas into a lifetime total persisted in device store. measure_power (W) is derived
+        // from the same delta over elapsed time.
+        if (feature.feature === PATHS.POWER_CONSUMPTION_TOTAL) {
+          const todayKwh = getValue(feature.properties, 'day.value.0');
+          if (typeof todayKwh === 'number') {
+            const now = Date.now();
+            const lastDayKwh = this.getStoreValue('lastDayKwh');
+            const previousLifetime = this.getStoreValue('lifetimeKwh');
+            const lifetimeBase = typeof previousLifetime === 'number' ? previousLifetime : 0;
+
+            let deltaKwh;
+            if (typeof lastDayKwh !== 'number') {
+              // First reading after install/upgrade — seed the lifetime total with today's value
+              deltaKwh = todayKwh;
+            } else if (todayKwh >= lastDayKwh) {
+              deltaKwh = todayKwh - lastDayKwh;
+            } else {
+              // Midnight reset — yesterday's final is already in the lifetime total
+              deltaKwh = todayKwh;
+            }
+
+            const lifetimeKwh = lifetimeBase + deltaKwh;
+            await this.setStoreValue('lifetimeKwh', lifetimeKwh);
+            await this.setStoreValue('lastDayKwh', todayKwh);
+            await this.setCapabilityValueIfPossible('meter_power', lifetimeKwh);
+
+            if (deltaKwh > 0) {
+              if (this._lastPowerTimestamp !== null) {
+                const deltaHours = (now - this._lastPowerTimestamp) / 3600000;
+                if (deltaHours > 0) {
+                  const watts = (deltaKwh / deltaHours) * 1000;
+                  await this.setStoreValue('lastMeasurePower', watts);
+                  await this.setCapabilityValueIfPossible('measure_power', watts);
+                }
+              }
+              this._lastPowerTimestamp = now;
+              await this.setStoreValue('lastPowerTimestamp', now);
+            }
           }
         }
       }
@@ -463,6 +526,13 @@ module.exports = class ViessmannDevice extends OAuth2Device {
     // Stop polling for this device
     const deviceKey = `${this._installationId}-${this._gatewaySerial}-${this._deviceId}`;
     this.driver._stopPolling(deviceKey);
+  }
+
+  async onSettings({ changedKeys }) {
+    if (changedKeys.includes('pollInterval')) {
+      const deviceKey = `${this._installationId}-${this._gatewaySerial}-${this._deviceId}`;
+      await this.driver._startPolling(this, deviceKey);
+    }
   }
 
   // Method to handle dynamic feature paths based on installation

--- a/drivers/vicare/device.js
+++ b/drivers/vicare/device.js
@@ -29,6 +29,7 @@ module.exports = class ViessmannDevice extends OAuth2Device {
 
   static FEATURES = FEATURES;
   static PATHS = PATHS;
+  static STATIC_CAPABILITIES = ['button.refresh'];
 
   async onOAuth2Init() {
     await this.checkUpgradeSpecifics();
@@ -54,15 +55,20 @@ module.exports = class ViessmannDevice extends OAuth2Device {
     }
 
     this._listeners = [];
-    this._lastPowerTimestamp = this.getStoreValue('lastPowerTimestamp') || null;
 
     await this.initializeCapabilities();
     await this.initializeOperatingModes();
     await this.registerCapabilityListeners();
 
+    this.registerCapabilityListener('button.refresh', async () => {
+      this.log('Manual refresh requested');
+      const deviceKey = `${this._installationId}-${this._gatewaySerial}-${this._deviceId}`;
+      await this.driver._startPolling(this, deviceKey);
+    });
+
     const lastMeasurePower = this.getStoreValue('lastMeasurePower');
     if (typeof lastMeasurePower === 'number') {
-      await this.setCapabilityValueIfPossible('measure_power', lastMeasurePower);
+      await this.setCapabilityValueIfPossible('measure_power', Math.max(0, lastMeasurePower));
     }
 
     this.onFeaturesUpdated = this.onFeaturesUpdated.bind(this);
@@ -79,8 +85,16 @@ module.exports = class ViessmannDevice extends OAuth2Device {
   }
 
   async initializeCapabilities() {
+    // Ensure static (non-feature-driven) capabilities are always present
+    for (const cap of this.constructor.STATIC_CAPABILITIES) {
+      if (!this.hasCapability(cap)) {
+        await this.addCapability(cap);
+      }
+    }
+
     // Remove capabilities that are no longer in config or don't match device roles
     for (const existingCap of this.getCapabilities()) {
+      if (this.constructor.STATIC_CAPABILITIES.includes(existingCap)) continue;
       let shouldKeep = false;
       for (const path of Object.values(PATHS)) {
         try {
@@ -387,43 +401,61 @@ module.exports = class ViessmannDevice extends OAuth2Device {
         // Viessmann's day[0] is today's kWh and resets at midnight. Homey's Energy tab requires
         // a monotonically increasing meter_power (energy.cumulative: true), so accumulate positive
         // deltas into a lifetime total persisted in device store. measure_power (W) is derived
-        // from the same delta over elapsed time.
+        // from the API's own update timestamp (feature.timestamp) — using wall-clock poll time
+        // produces fake spikes when a 0.1 kWh chunk that accumulated over hours is attributed to
+        // the gap between two polls.
         if (feature.feature === PATHS.POWER_CONSUMPTION_TOTAL) {
           const todayKwh = getValue(feature.properties, 'day.value.0');
-          if (typeof todayKwh === 'number') {
-            const now = Date.now();
+          const apiTimestampMs = feature.timestamp ? Date.parse(feature.timestamp) : NaN;
+          this.log(`[power] raw day.value.0 = ${todayKwh} apiTimestamp = ${feature.timestamp}`);
+          if (typeof todayKwh === 'number' && Number.isFinite(apiTimestampMs)) {
             const lastDayKwh = this.getStoreValue('lastDayKwh');
+            const lastApiTimestamp = this.getStoreValue('lastApiTimestamp');
             const previousLifetime = this.getStoreValue('lifetimeKwh');
             const lifetimeBase = typeof previousLifetime === 'number' ? previousLifetime : 0;
 
             let deltaKwh;
+            let deltaReason;
             if (typeof lastDayKwh !== 'number') {
-              // First reading after install/upgrade — seed the lifetime total with today's value
               deltaKwh = todayKwh;
+              deltaReason = 'first reading (seeded)';
             } else if (todayKwh >= lastDayKwh) {
               deltaKwh = todayKwh - lastDayKwh;
+              deltaReason = 'today >= last';
             } else {
-              // Midnight reset — yesterday's final is already in the lifetime total
               deltaKwh = todayKwh;
+              deltaReason = 'midnight reset';
             }
 
             const lifetimeKwh = lifetimeBase + deltaKwh;
+            const apiAdvanced = typeof lastApiTimestamp === 'number' && apiTimestampMs > lastApiTimestamp;
+            const deltaHours = typeof lastApiTimestamp === 'number'
+              ? (apiTimestampMs - lastApiTimestamp) / 3600000
+              : null;
+            this.log(
+              `[power] todayKwh=${todayKwh} lastDayKwh=${lastDayKwh} deltaKwh=${deltaKwh} (${deltaReason}) `
+              + `lifetimeBase=${lifetimeBase} lifetimeKwh=${lifetimeKwh} `
+              + `lastApiTimestamp=${lastApiTimestamp} apiAdvanced=${apiAdvanced} deltaHours=${deltaHours}`,
+            );
+
             await this.setStoreValue('lifetimeKwh', lifetimeKwh);
             await this.setStoreValue('lastDayKwh', todayKwh);
             await this.setCapabilityValueIfPossible('meter_power', lifetimeKwh);
 
-            if (deltaKwh > 0) {
-              if (this._lastPowerTimestamp !== null) {
-                const deltaHours = (now - this._lastPowerTimestamp) / 3600000;
-                if (deltaHours > 0) {
-                  const watts = (deltaKwh / deltaHours) * 1000;
-                  await this.setStoreValue('lastMeasurePower', watts);
-                  await this.setCapabilityValueIfPossible('measure_power', watts);
-                }
-              }
-              this._lastPowerTimestamp = now;
-              await this.setStoreValue('lastPowerTimestamp', now);
+            if (apiAdvanced && deltaHours > 0) {
+              const watts = Math.max(0, (deltaKwh / deltaHours) * 1000);
+              this.log(`[power] measure_power = ${watts} W (deltaKwh=${deltaKwh} / deltaHours=${deltaHours} * 1000)`);
+              await this.setStoreValue('lastMeasurePower', watts);
+              await this.setCapabilityValueIfPossible('measure_power', watts);
+              await this.setStoreValue('lastApiTimestamp', apiTimestampMs);
+            } else if (typeof lastApiTimestamp !== 'number') {
+              this.log('[power] first reading — recording API timestamp, deferring measure_power until next update');
+              await this.setStoreValue('lastApiTimestamp', apiTimestampMs);
+            } else {
+              this.log(`[power] API counter not advanced yet (last=${lastApiTimestamp}, now=${apiTimestampMs}) — leaving measure_power unchanged`);
             }
+          } else {
+            this.log(`[power] todayKwh not a number, skipping (type=${typeof todayKwh})`);
           }
         }
       }

--- a/drivers/vicare/driver.compose.json
+++ b/drivers/vicare/driver.compose.json
@@ -4,8 +4,12 @@
     "en": "ViCare"
   },
   "class": "heater",
-  "capabilities": [],
+  "capabilities": [
+    "meter_power",
+    "measure_power"
+  ],
   "capabilitiesOptions": {},
+  "energy": {},
   "platforms": [
     "local"
   ],
@@ -38,6 +42,22 @@
     {
       "id": "login_oauth2",
       "template": "login_oauth2"
+    }
+  ],
+  "settings": [
+    {
+      "id": "pollInterval",
+      "type": "number",
+      "label": {
+        "en": "Poll interval (minutes)"
+      },
+      "hint": {
+        "en": "How often this device polls the Viessmann API. The free Basic tier allows 120 calls per day per Client ID — keep this high enough that calls/day × devices stays under that limit."
+      },
+      "value": 2,
+      "min": 1,
+      "step": 1,
+      "units": "min"
     }
   ]
 }

--- a/drivers/vicare/driver.compose.json
+++ b/drivers/vicare/driver.compose.json
@@ -4,18 +4,8 @@
     "en": "ViCare"
   },
   "class": "heater",
-  "capabilities": [
-    "meter_power",
-    "measure_power",
-    "button.refresh"
-  ],
-  "capabilitiesOptions": {
-    "button.refresh": {
-      "title": { "en": "Refresh" },
-      "desc": { "en": "Fetch the latest data from the Viessmann API now" },
-      "maintenanceAction": true
-    }
-  },
+  "capabilities": [],
+  "capabilitiesOptions": {},
   "energy": {},
   "platforms": [
     "local"
@@ -65,6 +55,34 @@
       "min": 1,
       "step": 1,
       "units": "min"
+    },
+    {
+      "id": "baselineW",
+      "type": "number",
+      "label": {
+        "en": "Baseline power draw (W)"
+      },
+      "hint": {
+        "en": "Estimated standby power draw when the compressor is OFF (circulator pump, controller, etc.). Used to compute live measure_power when no kWh delta is available."
+      },
+      "value": 150,
+      "min": 0,
+      "step": 10,
+      "units": "W"
+    },
+    {
+      "id": "maxCompressorW",
+      "type": "number",
+      "label": {
+        "en": "Max compressor power draw (W)"
+      },
+      "hint": {
+        "en": "Estimated electrical draw of the compressor at its maximum speed (typically ~120 rps for inverter heat pumps). Live measure_power is scaled linearly from compressor.speed when the compressor is active. Tune to match what the Viessmann ViCare app shows during a steady-state cycle. Set to 0 to disable the compressor-based estimate and fall back to kWh-delta derivation."
+      },
+      "value": 3500,
+      "min": 0,
+      "step": 100,
+      "units": "W"
     }
   ]
 }

--- a/drivers/vicare/driver.compose.json
+++ b/drivers/vicare/driver.compose.json
@@ -6,9 +6,16 @@
   "class": "heater",
   "capabilities": [
     "meter_power",
-    "measure_power"
+    "measure_power",
+    "button.refresh"
   ],
-  "capabilitiesOptions": {},
+  "capabilitiesOptions": {
+    "button.refresh": {
+      "title": { "en": "Refresh" },
+      "desc": { "en": "Fetch the latest data from the Viessmann API now" },
+      "maintenanceAction": true
+    }
+  },
   "energy": {},
   "platforms": [
     "local"

--- a/drivers/vicare/driver.js
+++ b/drivers/vicare/driver.js
@@ -116,13 +116,21 @@ module.exports = class ViessmannDriver extends OAuth2Driver {
     this.log('Finished registering flow cards');
   }
 
-  _calculatePollInterval(device) {
-    const { DEFAULT_POLL_INTERVAL_MINUTES, MIN_POLL_INTERVAL_MINUTES } = this.constructor;
-    const raw = Number(device.getSetting('pollInterval'));
-    const minutes = Number.isFinite(raw) && raw > 0
-      ? Math.max(raw, MIN_POLL_INTERVAL_MINUTES)
+  // Convert raw minutes (from a setting value or anywhere else) to a
+  // sanitised interval in milliseconds. Centralised so onSettings — where
+  // device.getSetting() may still return the previous value — can convert
+  // the new value directly without re-reading from settings.
+  static _toIntervalMs(rawMinutes) {
+    const { DEFAULT_POLL_INTERVAL_MINUTES, MIN_POLL_INTERVAL_MINUTES } = this;
+    const num = Number(rawMinutes);
+    const minutes = Number.isFinite(num) && num > 0
+      ? Math.max(num, MIN_POLL_INTERVAL_MINUTES)
       : DEFAULT_POLL_INTERVAL_MINUTES;
     return minutes * 60 * 1000;
+  }
+
+  _calculatePollInterval(device) {
+    return this.constructor._toIntervalMs(device.getSetting('pollInterval'));
   }
 
   async _startPolling(device, deviceKey, interval = null) {
@@ -139,7 +147,7 @@ module.exports = class ViessmannDriver extends OAuth2Driver {
         try {
           // get features with extended response every 30th poll (statisticaly)
           const extendedRequest = Math.random() < 0.03;
-          const features = await device.getFeatures({ useFilter: !extendedRequest });
+          const features = await device.getFeatures(!extendedRequest);
 
           consecutiveErrors = 0;
           if (!device.getAvailable()) {

--- a/drivers/vicare/driver.js
+++ b/drivers/vicare/driver.js
@@ -29,7 +29,9 @@ module.exports = class ViessmannDriver extends OAuth2Driver {
   static FEATURES = FEATURES;
   static PATHS = PATHS;
 
-  MIN_POLL_INTERVAL = 2 * 60 * 1000;
+  static DEFAULT_POLL_INTERVAL_MINUTES = 2;
+  static MIN_POLL_INTERVAL_MINUTES = 1;
+
   _devicePollers = new Map();
   _triggerCards = new Map();
 
@@ -114,31 +116,20 @@ module.exports = class ViessmannDriver extends OAuth2Driver {
     this.log('Finished registering flow cards');
   }
 
-  _calculatePollInterval() {
-    const deviceCount = this.getDevices().length;
-    return this.MIN_POLL_INTERVAL * deviceCount;
-  }
-
-  async _updateAllPollingIntervals() {
-    const newInterval = this._calculatePollInterval();
-    const devices = this.getDevices();
-
-    if (process.env.DEBUG) {
-      this.log(`Updating polling interval for ${devices.length} devices to ${newInterval / 1000} seconds`);
-    }
-
-    await Promise.all(devices.map(async (device) => {
-      const { installationId, gatewaySerial, deviceId } = device.getStore();
-      const deviceKey = `${installationId}-${gatewaySerial}-${deviceId}`;
-      await this._startPolling(device, deviceKey, newInterval);
-    }));
+  _calculatePollInterval(device) {
+    const { DEFAULT_POLL_INTERVAL_MINUTES, MIN_POLL_INTERVAL_MINUTES } = this.constructor;
+    const raw = Number(device.getSetting('pollInterval'));
+    const minutes = Number.isFinite(raw) && raw > 0
+      ? Math.max(raw, MIN_POLL_INTERVAL_MINUTES)
+      : DEFAULT_POLL_INTERVAL_MINUTES;
+    return minutes * 60 * 1000;
   }
 
   async _startPolling(device, deviceKey, interval = null) {
     try {
       this.log(`Setting up polling for device: ${deviceKey}`);
       let consecutiveErrors = 0;
-      const pollInterval = interval || this._calculatePollInterval();
+      const pollInterval = interval || this._calculatePollInterval(device);
 
       // Stop any existing polling
       this._stopPolling(deviceKey);

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,6 +29,11 @@
           "description": "Select which device to get features for",
           "select": "Select a device...",
           "refresh": "Refresh Devices"
+        },
+        "power": {
+          "title": "Power Measurement",
+          "description": "Fetch the latest data from the API and update the power reading now.",
+          "refresh": "Refresh Power Now"
         }
       }
     },

--- a/scripts/getRefreshToken.js
+++ b/scripts/getRefreshToken.js
@@ -1,0 +1,177 @@
+/*
+ * One-time helper to mint a Viessmann refresh token from a browser login.
+ *
+ * Why this exists: the Viessmann API uses OAuth2 + PKCE only (no password
+ * grant). To run scripts/testConnection.js we need a refresh_token; this
+ * script walks through the one-time browser flow to get one.
+ *
+ * Flow:
+ *   1. Reads VIESSMANN_CLIENT_ID from .env (must already be set).
+ *   2. Prints an authorization URL. You open it in a browser, log in with
+ *      your Viessmann account, and approve.
+ *   3. Browser redirects to the registered redirect URI
+ *      (https://callback.athom.com/oauth2/callback) with ?code=... in the
+ *      URL. Copy that `code` value from the URL bar.
+ *   4. Paste the code back into this script when prompted.
+ *   5. Script exchanges code for access + refresh tokens, writes
+ *      VIESSMANN_REFRESH_TOKEN into .env, and exits.
+ *
+ * Reuses the same CODE_VERIFIER / code_challenge constants as the Homey
+ * app (lib/ViessmannOAuth2Client.js), so PKCE matches.
+ *
+ * Run from the viessmann/ directory:   node scripts/getRefreshToken.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const querystring = require('querystring');
+
+const AUTHORIZATION_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/authorize';
+const TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token';
+const REDIRECT_URI = 'https://callback.athom.com/oauth2/callback';
+const SCOPES = ['IoT', 'User', 'offline_access'];
+
+// Lifted verbatim from lib/ViessmannOAuth2Client.js so the PKCE pair matches.
+const CODE_VERIFIER = '6PygdmeK8JKPuuftlkc6q4ceyvjhMM_a_cJrPbcmcLc-SPjx2ZXTYr-SOofPUBydQ3McNYRy7Hibc2L2WtVLJFpOQ~Qbgic455ArKjUz9_UiTLnO6q8A3e.I_fIF8hAo';
+const CODE_CHALLENGE = '5M5nhkBfkWZCGfLZYcTL-l7esjPUN7PpZ4rq8k4cmys';
+
+const ENV_PATH = path.join(__dirname, '..', '.env');
+
+function loadEnv() {
+  if (!fs.existsSync(ENV_PATH)) {
+    console.error(`[FAIL] .env not found at ${ENV_PATH}`);
+    console.error('       Copy .env.example to .env and put your VIESSMANN_CLIENT_ID in it first.');
+    process.exit(1);
+  }
+  for (const line of fs.readFileSync(ENV_PATH, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+function writeRefreshTokenToEnv(refreshToken) {
+  const original = fs.readFileSync(ENV_PATH, 'utf8');
+  const lines = original.split(/\r?\n/);
+  let found = false;
+  const updated = lines.map((line) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#') || !trimmed.includes('=')) return line;
+    const key = trimmed.slice(0, trimmed.indexOf('=')).trim();
+    if (key === 'VIESSMANN_REFRESH_TOKEN') {
+      found = true;
+      return `VIESSMANN_REFRESH_TOKEN=${refreshToken}`;
+    }
+    return line;
+  });
+  if (!found) {
+    if (updated.length > 0 && updated[updated.length - 1] !== '') updated.push('');
+    updated.push(`VIESSMANN_REFRESH_TOKEN=${refreshToken}`);
+  }
+  fs.writeFileSync(ENV_PATH, updated.join('\n'));
+}
+
+function prompt(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+function extractCode(input) {
+  // Accept either a bare code or the whole redirect URL pasted in.
+  if (input.includes('code=')) {
+    try {
+      const url = new URL(input);
+      const code = url.searchParams.get('code');
+      if (code) return code;
+    } catch {
+      // not a URL — fall through to regex
+    }
+    const m = input.match(/[?&]code=([^&\s]+)/);
+    if (m) return decodeURIComponent(m[1]);
+  }
+  return input;
+}
+
+async function main() {
+  loadEnv();
+  const clientId = process.env.VIESSMANN_CLIENT_ID;
+  if (!clientId) {
+    console.error('[FAIL] VIESSMANN_CLIENT_ID is not set in .env');
+    process.exit(1);
+  }
+
+  const state = Math.random().toString(36).slice(2);
+  const authUrl = `${AUTHORIZATION_URL}?${querystring.stringify({
+    client_id: clientId,
+    redirect_uri: REDIRECT_URI,
+    response_type: 'code',
+    scope: SCOPES.join(' '),
+    state,
+    code_challenge_method: 'S256',
+    code_challenge: CODE_CHALLENGE,
+  })}`;
+
+  console.log('\n=== Step 1: open this URL in a browser and log in ===\n');
+  console.log(authUrl);
+  console.log('\nAfter you log in and approve, the browser will redirect to:');
+  console.log(`  ${REDIRECT_URI}?code=<long string>&state=${state}`);
+  console.log('(The Athom page may look blank or show a generic message — that is fine.)');
+  console.log('\n=== Step 2: copy the `code` value from the URL bar ===');
+  console.log('You can paste either just the code, or the entire redirected URL.\n');
+
+  const raw = await prompt('Paste here: ');
+  const code = extractCode(raw);
+  if (!code) {
+    console.error('[FAIL] No code provided.');
+    process.exit(1);
+  }
+
+  console.log('\n[*] Exchanging code for tokens...');
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: querystring.stringify({
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      code,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: CODE_VERIFIER,
+    }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    console.error(`[FAIL] Token exchange failed (${res.status}):`);
+    console.error(JSON.stringify(body, null, 2));
+    process.exit(1);
+  }
+  if (!body.refresh_token) {
+    console.error('[FAIL] No refresh_token in response:');
+    console.error(JSON.stringify(body, null, 2));
+    process.exit(1);
+  }
+
+  writeRefreshTokenToEnv(body.refresh_token);
+  console.log('[OK] refresh_token written to .env');
+  console.log(`     access_token expires in ${body.expires_in}s (you don\'t need to save this)`);
+  console.log('\nYou can now run:  node scripts/testConnection.js');
+}
+
+main().catch((err) => {
+  console.error('\n[FAIL]', err.message);
+  process.exit(1);
+});

--- a/scripts/testConnection.js
+++ b/scripts/testConnection.js
@@ -1,0 +1,406 @@
+/*
+ * Standalone connectivity test for the Viessmann ViCare API.
+ *
+ *   1. Reads VIESSMANN_CLIENT_ID + VIESSMANN_REFRESH_TOKEN from .env
+ *   2. Exchanges the refresh token for an access token
+ *   3. GET /equipment/installations?includeGateways=true
+ *   4. Picks the first installation -> first gateway -> first device
+ *   5. Fetches /features TWICE (unfiltered + filtered with the driver's
+ *      exact filter string) and diffs them.
+ *   6. Dumps the new primary source feature
+ *      (heating.power.consumption.summary.heating) plus every feature
+ *      whose name matches /consumption|power|energy/i so the right
+ *      counter can be confirmed.
+ *   7. SIMULATION: runs the exact same delta math as device.js (the new
+ *      summary.* accumulator) against live API data. State persists in
+ *      scripts/.testConnection.state.json between runs so calling the
+ *      script twice in a row simulates two consecutive driver polls.
+ *      Optional env: VIESSMANN_LIFETIME_SEED to seed lifetimeKwh on the
+ *      first run (e.g. 94300 to start from the user's current Homey value).
+ *
+ * Run from the viessmann/ directory:   node scripts/testConnection.js
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const querystring = require('querystring');
+
+const { PATHS } = require('../drivers/vicare/config');
+
+const API_URL = 'https://api.viessmann-climatesolutions.com/iot/v2';
+const TOKEN_URL = 'https://iam.viessmann-climatesolutions.com/idp/v3/token';
+
+// The driver's primary energy source feature (since 1.0.16).
+const POWER_FEATURE = PATHS.POWER_CONSUMPTION_SUMMARY_HEATING;
+const DRIVER_FILTER = Object.values(PATHS).join(',');
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env');
+  if (!fs.existsSync(envPath)) {
+    console.error(`[FAIL] .env not found at ${envPath}`);
+    console.error('       Copy .env.example to .env and fill in your credentials.');
+    process.exit(1);
+  }
+  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+async function refreshAccessToken(clientId, refreshToken) {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: querystring.stringify({
+      client_id: clientId,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`Token refresh failed (${res.status}): ${JSON.stringify(body)}`);
+  }
+  if (!body.access_token) {
+    throw new Error(`Token refresh returned no access_token: ${JSON.stringify(body)}`);
+  }
+  return body.access_token;
+}
+
+async function apiGet(accessToken, pathAndQuery) {
+  const res = await fetch(`${API_URL}${pathAndQuery}`, {
+    headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`GET ${pathAndQuery} failed (${res.status}): ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function homeyGetDevice() {
+  const baseUrl = process.env.HOMEY_LOCAL_URL;
+  const token = process.env.HOMEY_TOKEN;
+  const deviceId = process.env.HOMEY_DEVICE_ID;
+  if (!baseUrl || !token || !deviceId) return null;
+  try {
+    const res = await fetch(`${baseUrl}/api/manager/devices/device/${deviceId}`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      return { error: `HTTP ${res.status}` };
+    }
+    const body = await res.json();
+    const caps = body.capabilitiesObj || {};
+    return {
+      meter_power: caps.meter_power ? caps.meter_power.value : null,
+      meter_power_at: caps.meter_power ? new Date(caps.meter_power.lastUpdated).toISOString() : null,
+      measure_power: caps.measure_power ? caps.measure_power.value : null,
+      measure_power_at: caps.measure_power ? new Date(caps.measure_power.lastUpdated).toISOString() : null,
+    };
+  } catch (err) {
+    return { error: err.message };
+  }
+}
+
+async function main() {
+  loadEnv();
+
+  const clientId = process.env.VIESSMANN_CLIENT_ID;
+  const refreshToken = process.env.VIESSMANN_REFRESH_TOKEN;
+  if (!clientId || !refreshToken) {
+    console.error('[FAIL] VIESSMANN_CLIENT_ID and VIESSMANN_REFRESH_TOKEN must be set in .env');
+    process.exit(1);
+  }
+
+  console.log('[1/5] Refreshing access token...');
+  const accessToken = await refreshAccessToken(clientId, refreshToken);
+  console.log(`      OK (token length ${accessToken.length})`);
+
+  console.log('[2/5] GET /equipment/installations?includeGateways=true');
+  const installations = await apiGet(accessToken, '/equipment/installations?includeGateways=true');
+  const list = installations.data || [];
+  console.log(`      OK (${list.length} installation${list.length === 1 ? '' : 's'})`);
+  if (list.length === 0) {
+    console.error('[FAIL] No installations returned for this account.');
+    process.exit(1);
+  }
+
+  const installation = list[0];
+  const installationId = installation.id;
+  const gateways = installation.gateways || [];
+  if (gateways.length === 0) {
+    console.error(`[FAIL] Installation ${installationId} has no gateways.`);
+    process.exit(1);
+  }
+  const gateway = gateways[0];
+  const gatewaySerial = gateway.serial;
+  console.log(`      installationId=${installationId}  gatewaySerial=${gatewaySerial}`);
+
+  console.log('[3/5] GET devices');
+  const devicesResp = await apiGet(
+    accessToken,
+    `/equipment/installations/${installationId}/gateways/${gatewaySerial}/devices`,
+  );
+  const devices = devicesResp.data || [];
+  console.log(`      OK (${devices.length} device${devices.length === 1 ? '' : 's'})`);
+  for (const d of devices) {
+    console.log(`        - deviceId=${d.id}  type=${d.deviceType || 'n/a'}  model=${d.modelId || 'n/a'}  roles=${(d.roles || []).join('|') || 'n/a'}`);
+  }
+  // Match the driver's logic (drivers/vicare/driver.js:211): only deviceType === 'heating'
+  const heatingDevices = devices.filter((d) => d.deviceType === 'heating');
+  if (heatingDevices.length === 0) {
+    console.error('[FAIL] No devices with deviceType === "heating" — the Homey driver would skip all of these.');
+    process.exit(1);
+  }
+  const device = heatingDevices[0];
+  const deviceId = device.id;
+  console.log(`      picked first heating device: deviceId=${deviceId}  model=${device.modelId || 'n/a'}`);
+
+  const basePath = `/features/installations/${installationId}/gateways/${gatewaySerial}/devices/${deviceId}/features`;
+
+  console.log('[4/5] GET /features UNFILTERED (skipDisabled=true)');
+  const unfilteredResp = await apiGet(accessToken, `${basePath}?skipDisabled=true`);
+  const unfilteredFeatures = unfilteredResp.data || [];
+  const unfilteredNames = new Set(unfilteredFeatures.map((f) => f.feature));
+  console.log(`      OK (${unfilteredFeatures.length} features)`);
+
+  console.log('[5/5] GET /features FILTERED (the driver\'s exact filter string)');
+  console.log(`      filter = ${DRIVER_FILTER.slice(0, 80)}${DRIVER_FILTER.length > 80 ? '...' : ''}`);
+  console.log(`      filter length = ${DRIVER_FILTER.length} chars`);
+  const filteredResp = await apiGet(
+    accessToken,
+    `${basePath}?filter=${encodeURIComponent(DRIVER_FILTER)}&skipDisabled=true`,
+  );
+  const filteredFeatures = filteredResp.data || [];
+  const filteredNames = new Set(filteredFeatures.map((f) => f.feature));
+  console.log(`      OK (${filteredFeatures.length} features)`);
+
+  console.log('\n=== DIFF: PATHS members vs filtered/unfiltered responses ===');
+  const pathValues = Object.entries(PATHS);
+  console.log(`PATH KEY                              | unfiltered | filtered`);
+  console.log(`--------------------------------------+------------+---------`);
+  for (const [key, value] of pathValues) {
+    const inUnfiltered = unfilteredNames.has(value) ? 'YES' : ' . ';
+    const inFiltered = filteredNames.has(value) ? 'YES' : ' . ';
+    console.log(`${key.padEnd(38)}|    ${inUnfiltered}     |   ${inFiltered}`);
+  }
+
+  const missingInFiltered = [...unfilteredNames].filter(
+    (n) => Object.values(PATHS).includes(n) && !filteredNames.has(n),
+  );
+  if (missingInFiltered.length > 0) {
+    console.log('\n[!] Features present unfiltered but DROPPED by the driver\'s filter:');
+    for (const n of missingInFiltered) console.log(`    - ${n}`);
+  } else {
+    console.log('\n[OK] No PATHS features were dropped by the filter.');
+  }
+
+  console.log(`\n=== ${POWER_FEATURE} raw shape ===`);
+  const powerInUnfiltered = unfilteredFeatures.find((f) => f.feature === POWER_FEATURE);
+  const powerInFiltered = filteredFeatures.find((f) => f.feature === POWER_FEATURE);
+  if (!powerInUnfiltered) {
+    console.log(`[!] ${POWER_FEATURE} is NOT present even in the unfiltered response.`);
+    console.log('    -> Either disabled by skipDisabled=true, or this device does not expose it.');
+  } else {
+    console.log(`Unfiltered: present. timestamp=${powerInUnfiltered.timestamp}`);
+    console.log(`Filtered:   ${powerInFiltered ? 'present' : 'MISSING (filter drops it)'}`);
+    console.log('FULL properties =');
+    console.log(JSON.stringify(powerInUnfiltered.properties, null, 2));
+  }
+
+  // Dump every feature whose name suggests power/energy/consumption so we can
+  // find the counter that matches what the Viessmann mobile app displays.
+  console.log('\n=== All features matching /consumption|power/ ===');
+  const consumptionLike = unfilteredFeatures.filter(
+    (f) => /consumption|power|energy/i.test(f.feature),
+  );
+  console.log(`(${consumptionLike.length} features)\n`);
+  for (const f of consumptionLike) {
+    console.log(`---- ${f.feature}  (ts=${f.timestamp || 'n/a'}) ----`);
+    const props = f.properties || {};
+    for (const [propName, propValue] of Object.entries(props)) {
+      const v = propValue && typeof propValue === 'object' ? propValue.value : propValue;
+      const unit = propValue && propValue.unit ? ` ${propValue.unit}` : '';
+      if (Array.isArray(v)) {
+        const preview = v.slice(0, 4).map((x) => (typeof x === 'number' ? x.toFixed(2) : String(x))).join(', ');
+        const tail = v.length > 4 ? `, ... (${v.length} total)` : '';
+        console.log(`  ${propName}: [${preview}${tail}]${unit}`);
+      } else if (v !== undefined && v !== null && typeof v !== 'object') {
+        console.log(`  ${propName}: ${v}${unit}`);
+      } else if (v !== undefined && v !== null) {
+        console.log(`  ${propName}: ${JSON.stringify(v)}${unit}`);
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------------
+  // Simulation: mirror the exact delta math from device.js so we can verify
+  // what meter_power / measure_power WOULD be set to on the live device.
+  // State persists in scripts/.testConnection.state.json across runs, so
+  // running this script multiple times simulates multiple driver polls.
+  // ----------------------------------------------------------------------
+  console.log('\n=== SIMULATION: driver delta math against live API data ===');
+  const summaryPaths = [
+    PATHS.POWER_CONSUMPTION_SUMMARY_HEATING,
+    PATHS.POWER_CONSUMPTION_SUMMARY_DHW,
+    PATHS.POWER_CONSUMPTION_SUMMARY_COOLING,
+  ];
+  const summaryCurrentDay = {};
+  let latestSummaryTimestampMs = null;
+  for (const featurePath of summaryPaths) {
+    const f = unfilteredFeatures.find((x) => x.feature === featurePath);
+    if (!f) {
+      console.log(`  [skip] ${featurePath} not present in API response`);
+      continue;
+    }
+    const v = f.properties && f.properties.currentDay && f.properties.currentDay.value;
+    const tsMs = f.timestamp ? Date.parse(f.timestamp) : NaN;
+    if (typeof v === 'number') summaryCurrentDay[featurePath] = v;
+    if (Number.isFinite(tsMs) && (latestSummaryTimestampMs === null || tsMs > latestSummaryTimestampMs)) {
+      latestSummaryTimestampMs = tsMs;
+    }
+    console.log(`  ${featurePath.split('.').pop().padEnd(8)} currentDay=${v}  ts=${f.timestamp || 'n/a'}`);
+  }
+
+  const summaryKeys = Object.keys(summaryCurrentDay);
+  if (summaryKeys.length === 0 || latestSummaryTimestampMs === null) {
+    console.log('\n[!] No summary.* features with currentDay returned — driver would not update meter_power.');
+  } else {
+    const todayKwh = Object.values(summaryCurrentDay).reduce((sum, v) => sum + v, 0);
+    const apiTimestampMs = latestSummaryTimestampMs;
+
+    const statePath = path.join(__dirname, '.testConnection.state.json');
+    const seedFromEnv = process.env.VIESSMANN_LIFETIME_SEED
+      ? Number(process.env.VIESSMANN_LIFETIME_SEED) : undefined;
+    let prior;
+    if (fs.existsSync(statePath)) {
+      prior = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    } else if (Number.isFinite(seedFromEnv)) {
+      prior = { lifetimeKwh: seedFromEnv };
+    } else {
+      // Auto-seed from the live Homey value if HOMEY_* env vars are set.
+      // Falls back to 0 if not available.
+      const homeyForSeed = await homeyGetDevice();
+      if (homeyForSeed && typeof homeyForSeed.meter_power === 'number') {
+        // Subtract today's running sum so the upcoming first-reading-seeded
+        // delta produces a lifetimeKwh that matches what Homey already has.
+        prior = { lifetimeKwh: homeyForSeed.meter_power - todayKwh };
+        console.log(`  [auto-seed]  prior lifetimeKwh = ${prior.lifetimeKwh} (Homey actual ${homeyForSeed.meter_power} - todayKwh ${todayKwh})`);
+      } else {
+        prior = { lifetimeKwh: 0 };
+      }
+    }
+
+    const lastDayKwh = prior.lastDayKwh;
+    const lastApiTimestamp = prior.lastApiTimestamp;
+    const lifetimeBase = typeof prior.lifetimeKwh === 'number' ? prior.lifetimeKwh : 0;
+
+    let deltaKwh;
+    let deltaReason;
+    if (typeof lastDayKwh !== 'number') {
+      deltaKwh = todayKwh;
+      deltaReason = 'first reading (seeded)';
+    } else if (todayKwh >= lastDayKwh) {
+      deltaKwh = todayKwh - lastDayKwh;
+      deltaReason = 'today >= last';
+    } else {
+      deltaKwh = todayKwh;
+      deltaReason = 'midnight reset';
+    }
+
+    const lifetimeKwh = lifetimeBase + deltaKwh;
+    const apiAdvanced = typeof lastApiTimestamp === 'number' && apiTimestampMs > lastApiTimestamp;
+    const deltaHours = typeof lastApiTimestamp === 'number'
+      ? (apiTimestampMs - lastApiTimestamp) / 3600000
+      : null;
+
+    console.log(`\n  prior state from ${fs.existsSync(statePath) ? statePath : 'env/defaults'}:`);
+    console.log(`    lifetimeKwh        = ${lifetimeBase}`);
+    console.log(`    lastDayKwh         = ${lastDayKwh}`);
+    console.log(`    lastApiTimestamp   = ${lastApiTimestamp ? new Date(lastApiTimestamp).toISOString() : 'undefined'}`);
+    console.log(`\n  inputs from live API:`);
+    console.log(`    todayKwh           = ${todayKwh}  (${Object.entries(summaryCurrentDay).map(([k, v]) => `${k.split('.').pop()}=${v}`).join(' + ')})`);
+    console.log(`    apiTimestamp       = ${new Date(apiTimestampMs).toISOString()}`);
+    console.log(`\n  driver would set:`);
+    console.log(`    deltaKwh           = ${deltaKwh}  (${deltaReason})`);
+    console.log(`    meter_power        = ${lifetimeKwh.toFixed(3)} kWh   (lifetimeBase ${lifetimeBase} + deltaKwh ${deltaKwh})`);
+    // Live compressor-based measure_power estimate (matches device.js logic
+    // when the user has maxCompressorW > 0 — defaults to 3500). Falls back
+    // to the kWh-delta path when compressor data isn't present.
+    const MAX_STALE_POWER_MS = 15 * 60 * 1000;
+    const MAX_COMPRESSOR_RPS = 120;
+    const cf = unfilteredFeatures.find((x) => x.feature === PATHS.COMPRESSOR);
+    const csf = unfilteredFeatures.find((x) => x.feature === PATHS.COMPRESSOR_SPEED);
+    const ff = unfilteredFeatures.find((x) => x.feature === PATHS.PRIMARY_FAN_MODULATION);
+    const compressorActive = cf && cf.properties && cf.properties.active ? cf.properties.active.value : null;
+    const compressorSpeedRps = csf && csf.properties && csf.properties.value ? csf.properties.value.value : null;
+    const fanModulationPct = ff && ff.properties && ff.properties.value ? ff.properties.value.value : null;
+    const maxCompressorW = Number(process.env.VIESSMANN_MAX_COMPRESSOR_W);
+    const baselineW = Number(process.env.VIESSMANN_BASELINE_W) || 150;
+    const maxCompressorWEffective = Number.isFinite(maxCompressorW) ? maxCompressorW : 3500;
+
+    if (maxCompressorWEffective > 0 && typeof compressorActive === 'boolean') {
+      let watts;
+      if (compressorActive) {
+        const speedRatio = Math.min(1, Math.max(0, (compressorSpeedRps || 0) / MAX_COMPRESSOR_RPS));
+        watts = baselineW + speedRatio * maxCompressorWEffective;
+      } else {
+        watts = baselineW;
+      }
+      console.log(`    measure_power      = ${Math.round(watts)} W   (live: compressor=${compressorActive} speed=${compressorSpeedRps}rps fan=${fanModulationPct}% baselineW=${baselineW} maxCompressorW=${maxCompressorWEffective})`);
+    } else if (apiAdvanced && deltaHours > 0) {
+      const watts = Math.max(0, (deltaKwh / deltaHours) * 1000);
+      console.log(`    measure_power      = ${Math.round(watts)} W   (kWh-delta: ${deltaKwh} / ${deltaHours.toFixed(3)}h * 1000)`);
+    } else if (typeof lastApiTimestamp !== 'number') {
+      console.log('    measure_power      = unchanged  (first reading)');
+    } else {
+      const staleMs = Date.now() - lastApiTimestamp;
+      if (staleMs > MAX_STALE_POWER_MS) {
+        console.log(`    measure_power      = 0 W   (API timestamp stale for ${Math.round(staleMs / 60000)} min — assuming idle)`);
+      } else {
+        console.log(`    measure_power      = unchanged  (API timestamp has not advanced)`);
+      }
+    }
+
+    const newState = {
+      lifetimeKwh,
+      lastDayKwh: todayKwh,
+      lastApiTimestamp: apiAdvanced || typeof lastApiTimestamp !== 'number' ? apiTimestampMs : lastApiTimestamp,
+    };
+    fs.writeFileSync(statePath, `${JSON.stringify(newState, null, 2)}\n`);
+    console.log(`\n  state persisted to ${path.relative(process.cwd(), statePath)} — run again to simulate the next poll.`);
+
+    // Cross-check against the live Homey device, if HOMEY_* env vars are set.
+    const homey = await homeyGetDevice();
+    if (homey === null) {
+      console.log('\n  [no comparison]  HOMEY_LOCAL_URL / HOMEY_TOKEN / HOMEY_DEVICE_ID not set in .env');
+    } else if (homey.error) {
+      console.log(`\n  [Homey fetch failed]  ${homey.error}`);
+    } else {
+      const drift = typeof homey.meter_power === 'number'
+        ? (lifetimeKwh - homey.meter_power).toFixed(3) : 'n/a';
+      console.log('\n  Homey actual values (from local API):');
+      console.log(`    meter_power        = ${homey.meter_power} kWh   (updated ${homey.meter_power_at})`);
+      console.log(`    measure_power      = ${homey.measure_power} W   (updated ${homey.measure_power_at})`);
+      console.log(`    drift (sim - homey) = ${drift} kWh   ${Math.abs(Number(drift)) <= 1 ? '[MATCH]' : '[CHECK]'}`);
+    }
+  }
+
+  console.log('\n[DONE]');
+}
+
+main().catch((err) => {
+  console.error('\n[FAIL]', err.message);
+  process.exit(1);
+});

--- a/settings/index.html
+++ b/settings/index.html
@@ -81,6 +81,16 @@
           <button id="copyFeatures" class="homey-button-secondary" data-i18n="settings.troubleshooting.features.copy"></button>
         </div>
       </div>
+
+      <!-- Refresh Power -->
+      <div class="homey-form-group">
+        <label class="homey-form-label" data-i18n="settings.troubleshooting.power.title"></label>
+        <p class="homey-form-hint" data-i18n="settings.troubleshooting.power.description"></p>
+        <p id="powerResult" style="font-family: monospace; display: none;"></p>
+        <div class="homey-form-buttons">
+          <button id="refreshPower" class="homey-button-primary" data-i18n="settings.troubleshooting.power.refresh"></button>
+        </div>
+      </div>
     </fieldset>
 
     <script type="text/javascript">
@@ -96,6 +106,8 @@
         var featuresElement = document.getElementById("features");
         var deviceSelectElement = document.getElementById("deviceSelect");
         var refreshDevicesElement = document.getElementById("refreshDevices");
+        var refreshPowerElement = document.getElementById("refreshPower");
+        var powerResultElement = document.getElementById("powerResult");
 
         Homey.get("clientId", function (err, clientId) {
           if (err) return Homey.alert(err);
@@ -104,11 +116,11 @@
 
         saveElement.addEventListener("click", function (e) {
           const clientId = clientIdElement.value.trim();
-          
+
           if (!clientId || clientId.length < 5) {
             return Homey.alert(Homey.__("settings.error.invalid_client_id"));
           }
-          
+
           Homey.set("clientId", clientId, function (err) {
             if (err) return Homey.alert(err);
             Homey.alert(Homey.__("settings.saved"));
@@ -167,6 +179,23 @@
           Homey.api('POST', '/features', { deviceId: selectedDevice }, function(err, result) {
             if (err) return Homey.alert(err);
             featuresElement.textContent = JSON.stringify(result, null, 3);
+          });
+        });
+
+        refreshPowerElement.addEventListener("click", function (e) {
+          const selectedDevice = deviceSelectElement.options[deviceSelectElement.selectedIndex].value;
+          if (!selectedDevice) {
+            return Homey.alert(Homey.__("settings.error.no_device_selected"));
+          }
+
+          refreshPowerElement.disabled = true;
+          Homey.api('POST', '/refreshPower', { deviceId: selectedDevice }, function(err, result) {
+            refreshPowerElement.disabled = false;
+            if (err) return Homey.alert(err);
+            powerResultElement.style.display = 'block';
+            powerResultElement.textContent =
+              'Energy: ' + (result.meter_power !== null ? result.meter_power.toFixed(3) + ' kWh' : 'n/a') +
+              '  |  Power: ' + (result.measure_power !== null ? Math.round(result.measure_power) + ' W' : 'n/a');
           });
         });
 

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,76 @@
+# Todo
+
+## Energy reading shows lifetime total instead of today's consumption
+
+**Observed (device currently idle, not drawing power):**
+- Homey `Energy`: **94,300 kWh**
+- Homey `Power`: **0 W**  (looks correct)
+- Viessmann app, consumption today: **12.5 kWh**
+
+**Question:** Why does Homey show 94,300 kWh instead of 12.5 kWh?
+
+**Answer (root cause, by design):** The Viessmann API only exposes today's
+kWh in `heating.power.consumption.total` -> `day.value.0`, which resets at
+midnight. Homey's Energy tab requires `meter_power` to be a monotonically
+increasing lifetime counter (`energy.cumulative: true`), so the driver
+builds its own lifetime accumulator (`lifetimeKwh` in device store) by
+summing positive deltas every poll. See `drivers/vicare/device.js:401-460`
+and `drivers/vicare/config.js:53,396-417`.
+
+- 12.5 kWh = today's value Viessmann's app shows (raw API value)
+- 94,300 kWh = accumulator built up by the Homey driver since pairing
+
+**New symptom (12 hours stuck):** `meter_power` value in Homey Insights
+has not moved for 12 hours despite Viessmann app showing today's
+consumption growing. That means `day.value.0` deltas are not being
+applied.
+
+**Findings from `scripts/testConnection.js` on installation 3063056,
+device 0 (Vitocal 222S, E3_Vitocal_16):**
+
+- [x] **Bug 1 fixed.** `extendedRequest` arg-shape mismatch in
+      `driver.js:142` — now passes positional boolean.
+- [x] **Bug 2 dismissed.** Filter works correctly; both filtered and
+      unfiltered requests return `heating.power.consumption.total`.
+- [x] Extended `scripts/testConnection.js` to dump the full feature
+      tree. Confirmed two distinct issues on the Vitocal 222S:
+
+  **Issue A — `total.day` array is stale.** Outer `feature.timestamp`
+  = 2026-05-17T12:58 (fresh), but the inner `dayValueReadAt` =
+  **2026-05-15T20:31** (~40h old). The driver gates updates on
+  `feature.timestamp` (`device.js:409`), so each poll reads the same
+  frozen `day.value[0] = 1.1`, deltaKwh = 0, lifetime stays at 94,300.
+
+  **Issue B — `total.day[0]` doesn't equal "today's total".**
+  Doesn't match `summary.heating + summary.dhw + summary.cooling`.
+  The clean source on this device is `heating.power.consumption.summary.*`,
+  each with a `currentDay` property and a fresh outer timestamp:
+  summary.heating.currentDay (1.1) + summary.dhw.currentDay (9.7) +
+  summary.cooling.currentDay (0) = 10.8 kWh ~ Viessmann app's 12.5.
+
+- [x] **Switched source feature(s)** — `config.js` now declares three new
+      PATHS (`POWER_CONSUMPTION_SUMMARY_{HEATING,DHW,COOLING}`), and
+      `device.js` collects each `currentDay` during the feature loop, then
+      aggregates the sum into `meter_power` / `measure_power` once the
+      loop finishes. Delta is gated on the freshest summary timestamp
+      (no longer trusts the outer `total.timestamp` which lies). Added a
+      `storeVersionBefore('1.0.16')` migration that refreshes `_features`
+      from the API and unsets `lastDayKwh` / `lastApiTimestamp` so the
+      accumulator seeds cleanly from the new source on the next poll.
+      `scripts/testConnection.js` confirms the three new paths come back
+      YES/YES (both unfiltered and filtered).
+      **Bump `app.json` to 1.0.16 before publishing** so the migration runs.
+- [x] **Simulation verification.** `scripts/testConnection.js` now
+      mirrors the new driver math against live API data with state
+      persisted in `scripts/.testConnection.state.json`. Confirmed:
+      - First poll after migration with `VIESSMANN_LIFETIME_SEED=94300`:
+        deltaKwh = 10.8 (seeded), meter_power → 94,310.8 kWh.
+      - Second poll with no consumption: deltaKwh = 0, unchanged.
+      - Once `summary.heating.timestamp` advances + currentDay grows,
+        positive delta will produce a real `measure_power` watts value.
+
+- [ ] Add a seed-value sanity guard: if first-reading is implausibly
+      large (e.g. > 100 kWh), seed to 0 instead of trusting the value
+      (`device.js:419-421`).
+- [ ] Optionally add a separate, non-cumulative "today's kWh" capability
+      so the value matches what Viessmann's own app displays.


### PR DESCRIPTION
Hey @pelleros 

I changed so the device power consumption are a part of Energy panel.

## Changes

- Added `meter_power` (kWh) and `measure_power` (W) capabilities to the ViCare driver
- Power consumption is sourced from `heating.power.consumption.total` via the Viessmann API
- `meter_power` accumulates a lifetime kWh total across midnight resets, persisted in device store
- `measure_power` is computed as average watts between API updates (~30–60 min); only written when new data arrives
- Last computed `measure_power` value is persisted and restored on startup so Insights always has an immediate reading
- Device now appears as an energy consumer in Homey's Energy panel, tracked via `measure_power`
- Per-device poll interval setting added (default 2 min, minimum 1 min), configurable in device settings
- App version bumped to 1.0.15 with an upgrade step that refreshes the stored feature list from the API — existing paired devices pick up the new capabilities without re-pairing
- Added "Refresh Power Now" button in app settings → Troubleshooting to force-fetch the latest data and display current energy and power readings inline